### PR TITLE
Fix for tables with multiple rows and colspans in headers

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -22,10 +22,14 @@
             applyLast = (applyLast === true);
             $this.find('span.sign').remove();
             $this.find('thead tr').each(function (rowIndex) {
+                var columnsSkipped = 0;
                 $(this).find('th').each(function (columnIndex) {
                     var $this = $(this);
-                    $this.attr('data-sortcolumn', columnIndex);
+                    $this.attr('data-sortcolumn', columnIndex + columnsSkipped);
                     $this.attr('data-sortkey', columnIndex + '-' + rowIndex);
+                    if ($this.attr("colspan") !== undefined) {
+                        columnsSkipped += parseInt($this.attr("colspan")) - 1;
+                    }
                 });
             });
             $this.find('td').each(function () {


### PR DESCRIPTION
Hi. In a recent project I had a table where some of the columns had to be logically grouped.
Typically this can be implemented as a table with header containing multiple rows with some of the cells spanning multiple columns (see problem demo below for example).

There are 2 issues preventing current implementation from doing this:
1. sorting breaks when there are multiple rows in header.
2. sorting breaks when there are "colspans" in td's of the header.

This pull request contains 2 commits addressing these issues and allowing to create such tables.

Demo, showing the problem (open test.html and try to sort tables): https://github.com/EugenyLoy/bootstrap-sortable/tree/colspan_fix_problem_demo
Demo, showing solution: https://github.com/EugenyLoy/bootstrap-sortable/tree/colspan_fix_wip

Implementation tested on IE 8, IE 10, FF 25 and Chrome 31.
