### PR TITLE
make your plugin work with the floatThead plugin

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -43,12 +43,14 @@
             });
             $this.find('thead th[data-defaultsort!="disabled"]').each(function (index) {
                 var $this = $(this);
+                var $sortTable = $this.closest('table.sortable');
+                $this.data('sortTable', $sortTable);
                 var sortKey = $this.attr('data-sortkey');
                 var thisLastSort = applyLast ? lastSort : -1;
                 bsSort[sortKey] = applyLast ? bsSort[sortKey] : $this.attr('data-defaultsort');
                 if (bsSort[sortKey] != null && (applyLast == (sortKey == thisLastSort))) {
                     bsSort[sortKey] = bsSort[sortKey] == 'asc' ? 'desc' : 'asc';
-                    doSort($this, $this.parents('table.sortable'))
+                    doSort($this, $sortTable)
                 }
             });
             $this.trigger('sorted');
@@ -57,7 +59,7 @@
 
     // add click event to table header
     $document.on('click', 'table.sortable thead th[data-defaultsort!="disabled"]', function (e) {
-        var $this = $(this), $table = $this.parents('table.sortable');
+        var $this = $(this), $table = $this.data('sortTable') || $this.closest('table.sortable');
         doSort($this, $table);
         $table.trigger('sorted');
     });


### PR DESCRIPTION
This issue came up on my tracker:
https://github.com/mkoryak/floatThead/issues/37

Basically the floatThead plugin floats the table's header and lets you scroll within the table. 
It wasn't working with your plugin because how it looks up the table being sorted on every header click. 

This change caches the table being sorted for each sortable header cell. Later when you click the sort cell it will use that cached table object or fall back to a lookup. This makes it work with floatThead. 

I also changed the `.parents()` selector to `.closest()` because I think you only expect to find one table - correct me if I am wrong. 
