### PR TITLE
Fix: removed byte order mark (BOM) from CSS which was causing browsers t...

### DIFF
--- a/Contents/bootstrap-sortable.css
+++ b/Contents/bootstrap-sortable.css
@@ -1,4 +1,4 @@
-﻿table.sortable span.sign {
+table.sortable span.sign {
     display: block;
     position: absolute;
     top: 50%;


### PR DESCRIPTION
I noticed the `table.sortable span.sign` rule was being ignored in my application and tracked it down to a BOM / ZERO WIDTH NO-BREAK SPACE character at the beginning of the CSS. I don't know if this was partly to do with the minification/concatenation tool I'm using, but, I figured it was safe/recommended to remove regardless.
