### PR TITLE
Add class to sorted column cells

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -110,6 +110,11 @@
         // sort rows
         var rows = $table.children('tbody').children('tr');
         rows.tsort('td:eq(' + sortColumn + ')', { order: bsSort[sortKey], attr: 'data-value' });
+        
+        // add class to sorted column cells
+        $table.find('td.sorted, th.sorted').removeClass('sorted');
+        rows.find('td:eq(' + sortColumn + ')').addClass('sorted');
+        $this.addClass('sorted');
     }
 
     // jQuery 1.9 removed this object


### PR DESCRIPTION
In a table I was sorting I wanted to highlight the sorted column — set the `<th>` to bold, apply a background colour to the `<td>`s, and so forth. I added a class to each cell to achieve this. Ideally the class name would be configurable by passing an argument to `$.bootstrapSortable`, but I'll start with this commit.
