### PR TITLE
Added before-sort event

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -61,6 +61,7 @@
     // add click event to table header
     $document.on('click', 'table.sortable thead th[data-defaultsort!="disabled"]', function (e) {
         var $this = $(this), $table = $this.data('sortTable') || $this.closest('table.sortable');
+        $table.trigger('before-sort');
         doSort($this, $table);
         $table.trigger('sorted');
     });


### PR DESCRIPTION
For lengthy and verbose tables, sometimes we need multiple rows to improve readability:

![before-sort](https://cloud.githubusercontent.com/assets/1148372/5588164/bc69039a-90cf-11e4-8fed-38268f67dea8.png)

We can listen to the `sorted` event to create these striped rows (in my case, hide the verbose description column in question and recreate it below as a row with td colspans), but -- then the sorting capability gets disrupted.  Adding this `before-sort` event to the library allows us to remove the cosmetic rows before a sort, and then recreate them when done.
