### PR TITLE
Prevent rows sorting when there is no row in table.

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -184,7 +184,9 @@
 
         // sort rows
         var rows = $table.children('tbody').children('tr');
-        sortEngine(rows, { selector: 'td:nth-child(' + (sortColumn + 1) + ')', order: bsSort[sortKey], data: 'value' });
+        if (rows.length != 0) {
+            sortEngine(rows, { selector: 'td:nth-child(' + (sortColumn + 1) + ')', order: bsSort[sortKey], data: 'value' });
+        }
 
         // add class to sorted column cells
         $table.find('td.sorted, th.sorted').removeClass('sorted');


### PR DESCRIPTION
When data-defaultsort="asc" is used, and table is empty, the script throws an error.

Bug visible on :
http://jsfiddle.net/46H6W/55/

My patch disable sort when table does not contain any row, not sure it is a good fix...