### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "jasmine2-custom-message": "^0.8.0",
-    "jquery": "^2.1.4",
+    "jquery": "^3.4.0",
     "karma": "^0.13.16",
     "karma-jasmine": "^0.3.6",
     "karma-mocha-reporter": "^1.1.3",


### PR DESCRIPTION
The version of jQuery required should be at least 3.4.0 to avoid [security vulnerabilities](https://nvd.nist.gov/vuln/detail/CVE-2019-11358).