### PR TITLE
refactor: can sort td wrapped inside other elements

### DIFF
--- a/Scripts/bootstrap-sortable.js
+++ b/Scripts/bootstrap-sortable.js
@@ -295,7 +295,7 @@
         }
 
         // remove rows that should not be sorted
-        var rows = $table.children('tbody').children('tr');
+        var rows = $table.children('tbody').find('tr');
         var fixedRows = [];
         $(rows.filter('[data-disablesort="true"]').get().reverse()).each(function (index, fixedRow) {
             var $fixedRow = $(fixedRow);


### PR DESCRIPTION
The new code can also work for tables, where table rows are wrapped by e.g. <a> elements

```
<tbody>
    <a href="...">
        <tr>
            <td>
            ...
            </td>
        </tr>
    </a>
    ....
</tbody>
```